### PR TITLE
Add batch transcription, analysis, and concurrent UI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,30 @@
 ## 📌 איך מריצים
 
 1. התקנת סביבת עבודה:
-```bash
-pip install -r requirements.txt
-```
+   ```bash
+   pip install -r requirements.txt
+   ```
 
-2. הרצת ה־API:
-```bash
-uvicorn backend.backend:app --reload --port 8000
-```
+2. הרצת ה־API (בטרמינל אחד):
+   ```bash
+   uvicorn backend.backend:app --reload --port 8000
+   ```
 
-3. הרצת הממשק (UI):
-```bash
-streamlit run ui/ui_dashboard.py
-```
+3. הרצת הממשק (UI) בטרמינל נוסף:
+   ```bash
+   streamlit run ui/ui_dashboard.py
+   ```
+   ניתן גם להריץ את שתי הפקודות במקביל בעזרת `&` או בכלי כמו `tmux`.
 
 4. כניסה ל־Dashboard:
-[http://localhost:8501](http://localhost:8501)
+   [http://localhost:8501](http://localhost:8501)
+
+## Batch Processing
+
+ה־API תומך בהעלאת מספר קבצי שמע במקביל דרך הנתיב `/upload_batch`, והממשק יודע לשלוח קבצים מרובים בעת בחירה מרובה.
+
+## המשך פיתוח
+
+- שמירת נתונים ב־DB (PostgreSQL / MongoDB)
+- אימות משתמשים (JWT/OAuth)
+- חיוב לקוחות ושילוב ספק תשלומים

--- a/analysis/analyze_call.py
+++ b/analysis/analyze_call.py
@@ -1,3 +1,28 @@
-# Placeholder for call analysis logic
-def run_analysis(transcript_path: str):
-    return {"score": 85, "summary": "השיחה נוהלה בצורה טובה, הנציג טיפל ברוב ההתנגדויות."}
+import json
+from typing import Dict, List
+from concurrent.futures import ThreadPoolExecutor
+
+
+def _analyze_single(transcript_path: str) -> Dict[str, object]:
+    """A very naive analysis over the transcript JSON file."""
+    with open(transcript_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    segments = data.get("segments", [])
+    full_text = " ".join(seg.get("text", "") for seg in segments)
+    word_count = len(full_text.split())
+    # Naive scoring: one point for every 5 words, capped at 100
+    score = min(100, word_count // 5)
+    summary = full_text[:200]
+    return {"score": score, "summary": summary}
+
+
+def run_analysis(transcript_path: str) -> Dict[str, object]:
+    """Public API for single transcript analysis."""
+    return _analyze_single(transcript_path)
+
+
+def batch_analysis(transcript_paths: List[str]) -> List[Dict[str, object]]:
+    """Analyze multiple transcripts concurrently."""
+    with ThreadPoolExecutor() as executor:
+        return list(executor.map(_analyze_single, transcript_paths))

--- a/analysis/transcribe_and_diarize.py
+++ b/analysis/transcribe_and_diarize.py
@@ -1,8 +1,100 @@
-# Placeholder for transcription & diarization logic
-def run_transcription_and_diarization(audio_path: str, call_dir: str, engine="whisper", enable_diarization=True):
-    # Here you will plug in the actual Whisper/KolWrite/Pyannote logic
-    return {
-        "transcript_path": f"{call_dir}/transcript.json",
-        "call_dir": call_dir,
-        "status": "done (mocked)"
-    }
+from __future__ import annotations
+import os
+import json
+from pathlib import Path
+from typing import List, Tuple, Dict
+from concurrent.futures import ThreadPoolExecutor
+
+# Optional heavy imports. They may fail during tests if models are not installed
+try:  # pragma: no cover - import errors are handled gracefully
+    from faster_whisper import WhisperModel
+except Exception:  # pragma: no cover
+    WhisperModel = None  # type: ignore
+
+try:  # pragma: no cover
+    from pyannote.audio import Pipeline
+except Exception:  # pragma: no cover
+    Pipeline = None  # type: ignore
+
+_whisper_model = None
+_diarization_pipeline = None
+
+
+def _load_models(engine: str) -> None:
+    """Lazily load speech-to-text and diarization models."""
+    global _whisper_model, _diarization_pipeline
+    if engine == "whisper" and WhisperModel and _whisper_model is None:
+        _whisper_model = WhisperModel("base")
+    if Pipeline and _diarization_pipeline is None:
+        token = os.getenv("HUGGINGFACE_TOKEN")
+        _diarization_pipeline = Pipeline.from_pretrained(
+            "pyannote/speaker-diarization", use_auth_token=token
+        )
+
+
+def _transcribe_single(
+    audio_path: str,
+    call_dir: str,
+    engine: str = "whisper",
+    enable_diarization: bool = True,
+) -> Dict[str, str]:
+    """Transcribe and optionally diarize a single audio file."""
+    call_path = Path(call_dir)
+    call_path.mkdir(parents=True, exist_ok=True)
+    _load_models(engine)
+
+    transcript = []
+    if _whisper_model:
+        segments, _ = _whisper_model.transcribe(audio_path)
+        for seg in segments:
+            transcript.append(
+                {"start": seg.start, "end": seg.end, "text": seg.text.strip()}
+            )
+    else:  # pragma: no cover - fallback when model isn't available
+        transcript.append({"start": 0, "end": 0, "text": "[unavailable]"})
+
+    result: Dict[str, List[Dict[str, float | str]]] = {"segments": transcript}
+
+    if enable_diarization and _diarization_pipeline:
+        diarization = _diarization_pipeline(audio_path)
+        speakers = []
+        for turn, _, speaker in diarization.itertracks(yield_label=True):
+            speakers.append(
+                {"speaker": speaker, "start": turn.start, "end": turn.end}
+            )
+        result["speakers"] = speakers
+
+    transcript_path = call_path / "transcript.json"
+    with open(transcript_path, "w", encoding="utf-8") as f:
+        json.dump(result, f, ensure_ascii=False, indent=2)
+
+    return {"transcript_path": str(transcript_path), "call_dir": str(call_path)}
+
+
+def run_transcription_and_diarization(
+    audio_path: str,
+    call_dir: str,
+    engine: str = "whisper",
+    enable_diarization: bool = True,
+) -> Dict[str, str]:
+    """Public wrapper used by the API for a single file."""
+    return _transcribe_single(audio_path, call_dir, engine, enable_diarization)
+
+
+def batch_transcription(
+    items: List[Tuple[str, str]],
+    engine: str = "whisper",
+    enable_diarization: bool = True,
+) -> List[Dict[str, str]]:
+    """Process multiple audio files concurrently.
+
+    Each item is a tuple of (audio_path, call_dir).
+    """
+    with ThreadPoolExecutor() as executor:
+        futures = [
+            executor.submit(
+                _transcribe_single, audio, directory, engine, enable_diarization
+            )
+            for audio, directory in items
+        ]
+        return [f.result() for f in futures]

--- a/backend/backend.py
+++ b/backend/backend.py
@@ -1,15 +1,21 @@
 from fastapi import FastAPI, UploadFile, File
-import uuid, os, shutil
+from typing import List, Tuple
+import uuid, shutil
 from pathlib import Path
-from analysis.transcribe_and_diarize import run_transcription_and_diarization
+from analysis.transcribe_and_diarize import (
+    run_transcription_and_diarization,
+    batch_transcription,
+)
 
 app = FastAPI(title="CallIntel API")
 
 CALLS_DIR = Path("storage/calls")
 CALLS_DIR.mkdir(parents=True, exist_ok=True)
 
+
 @app.post("/upload")
 async def upload_file(file: UploadFile = File(...)):
+    """Upload and process a single audio file."""
     call_id = str(uuid.uuid4())
     call_dir = CALLS_DIR / call_id
     call_dir.mkdir(parents=True, exist_ok=True)
@@ -22,7 +28,29 @@ async def upload_file(file: UploadFile = File(...)):
         audio_path=str(audio_path),
         call_dir=str(call_dir),
         engine="whisper",
-        enable_diarization=True
+        enable_diarization=True,
     )
 
     return {"call_id": call_id, "result": result}
+
+
+@app.post("/upload_batch")
+async def upload_batch(files: List[UploadFile] = File(...)):
+    """Upload and process multiple audio files concurrently."""
+    items: List[Tuple[str, str]] = []
+    call_ids: List[str] = []
+
+    for file in files:
+        call_id = str(uuid.uuid4())
+        call_dir = CALLS_DIR / call_id
+        call_dir.mkdir(parents=True, exist_ok=True)
+        audio_path = call_dir / file.filename
+        with open(audio_path, "wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+        call_ids.append(call_id)
+        items.append((str(audio_path), str(call_dir)))
+
+    results = batch_transcription(
+        items, engine="whisper", enable_diarization=True
+    )
+    return {"call_ids": call_ids, "results": results}

--- a/ui/ui_dashboard.py
+++ b/ui/ui_dashboard.py
@@ -6,17 +6,24 @@ API_URL = "http://127.0.0.1:8000"
 st.set_page_config(page_title="CallIntel Dashboard", layout="wide")
 st.title("📞 CallIntel – ניתוח שיחות")
 
-uploaded_file = st.file_uploader("העלה הקלטת שיחה", type=["mp3", "wav", "m4a"])
+uploaded_files = st.file_uploader(
+    "העלה הקלטות שיחה", type=["mp3", "wav", "m4a"], accept_multiple_files=True
+)
 
-if uploaded_file is not None:
-    st.info("מעלה קובץ לשרת...")
-    files = {"file": (uploaded_file.name, uploaded_file.getvalue(), "audio/wav")}
-    response = requests.post(f"{API_URL}/upload", files=files)
+if uploaded_files:
+    if len(uploaded_files) == 1:
+        uploaded_file = uploaded_files[0]
+        st.info("מעלה קובץ לשרת...")
+        files = {"file": (uploaded_file.name, uploaded_file.getvalue(), "audio/wav")}
+        response = requests.post(f"{API_URL}/upload", files=files)
+    else:
+        st.info("מעלה קבצים לשרת (batch)...")
+        files = [("files", (f.name, f.getvalue(), "audio/wav")) for f in uploaded_files]
+        response = requests.post(f"{API_URL}/upload_batch", files=files)
 
     if response.status_code == 200:
         data = response.json()
-        call_id = data["call_id"]
-        st.success(f"שיחה הועלתה בהצלחה! מזהה: {call_id}")
-        st.json(data["result"])
+        st.success("העלאה הושלמה!")
+        st.json(data)
     else:
         st.error("שגיאה בהעלאה.")


### PR DESCRIPTION
## Summary
- expand transcription & diarization logic with batch processing and model loading
- add simple transcript analysis utilities including batch API
- support batch uploads in backend and Streamlit dashboard
- document running backend and UI in parallel and outline future improvements

## Testing
- `python -m py_compile analysis/transcribe_and_diarize.py analysis/analyze_call.py backend/backend.py ui/ui_dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68be79857d54832597500abbc1391a58